### PR TITLE
Hash optional types specially to unbox inner value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hashstructure [![GoDoc](https://godoc.org/github.com/mitchellh/hashstructure?status.svg)](https://godoc.org/github.com/mitchellh/hashstructure)
+# hashstructure [![GoDoc](https://godoc.org/go.openly.dev/hashstructure?status.svg)](https://godoc.org/go.openly.dev/hashstructure)
 
 hashstructure is a Go library for creating a unique hash value
 for arbitrary values in Go.
@@ -30,21 +30,12 @@ sending data across the network, caching values locally (de-dup), and so on.
 Standard `go get`:
 
 ```
-$ go get github.com/mitchellh/hashstructure/v2
+$ go get go.openly.dev/hashstructure
 ```
-
-**Note on v2:** It is highly recommended you use the "v2" release since this
-fixes some significant hash collisions issues from v1. In practice, we used
-v1 for many years in real projects at HashiCorp and never had issues, but it
-is highly dependent on the shape of the data you're hashing and how you use
-those hashes.
-
-When using v2+, you can still generate weaker v1 hashes by using the
-`FormatV1` format when calling `Hash`.
 
 ## Usage & Example
 
-For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/hashstructure).
+For usage and examples see the [Godoc](http://godoc.org/go.openly.dev/hashstructure).
 
 A quick code example is shown below:
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/mitchellh/hashstructure/v2
+module go.openly.dev/hashstructure
 
 go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module go.openly.dev/hashstructure
 
 go 1.18
+
+require github.com/markphelps/optional v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/markphelps/optional v0.11.0 h1:NiN3aRmUzs+nfdSaFQ646PmlbhVHr11mZU2DQMbWDfQ=
+github.com/markphelps/optional v0.11.0/go.mod h1:Fvjs1vxcm7/wDqJPFGEiEM1RuxFl9GCyxQlj9M9YMAQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/hashstructure.go
+++ b/hashstructure.go
@@ -322,6 +322,13 @@ func (w *walker) visitStruct(v reflect.Value) error {
 	}
 
 	t := v.Type()
+
+	// we need to "unbox" the value in an optional struct
+	// becuase the actual value is a private field
+	if t.PkgPath() == "github.com/markphelps/optional" {
+		return w.visitOptional(v, t.Name())
+	}
+
 	err := w.visit(reflect.ValueOf(t.Name()), nil)
 	if err != nil {
 		return err

--- a/optional.go
+++ b/optional.go
@@ -1,0 +1,292 @@
+package hashstructure
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/markphelps/optional"
+)
+
+func (w *walker) visitOptional(v reflect.Value, typeName string) error {
+	switch typeName {
+	case "String":
+		os := v.Interface().(optional.String)
+		str := "string" + os.OrElse("") // use a prefix to distinguish any possible value from nil case
+		if !os.Present() && !w.opts.ZeroNil {
+			str = "nil"
+		}
+		_, err := fmt.Fprint(w.h, str)
+		return err
+
+	case "Error":
+		os := v.Interface().(optional.Error)
+		str := "error" + os.OrElse(errors.New("")).Error() // use a prefix to distinguish any possible value from nil case
+		if !os.Present() && !w.opts.ZeroNil {
+			str = "nil"
+		}
+		_, err := fmt.Fprint(w.h, str)
+		return err
+
+	case "Bool":
+		ob := v.Interface().(optional.Bool)
+		if w.opts.IgnoreZeroValue && !ob.OrElse(false) {
+			return nil
+		}
+		str := "nil"
+		if ob.Present() {
+			str = fmt.Sprintf("%t", ob.OrElse(false))
+		}
+		if !ob.Present() && w.opts.ZeroNil {
+			str = "false" // treat nil as false
+		}
+		_, err := fmt.Fprint(w.h, str)
+		return err
+
+	case "Int8":
+		oi := v.Interface().(optional.Int8)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, int8(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == 0 {
+			return nil
+		}
+		if !oi.Present() {
+			// since no Go primitive numeric type is 3 bytes,
+			// there can exist no int8, uint8, 16, etc. that has the
+			// same bytes as the string "nil". Therefore, updating the hash state
+			// by writing "nil" will be distinct from any binary.Write below,
+			// which is what we want (distinguishing nil from 0 or any other "present" val)
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, oi.OrElse(0))
+
+	case "Byte":
+		oi := v.Interface().(optional.Byte)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, byte(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == 0 {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, oi.OrElse(0))
+
+	case "Int16":
+		oi := v.Interface().(optional.Int16)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, int16(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == 0 {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, oi.OrElse(0))
+
+	case "Int32":
+		oi := v.Interface().(optional.Int32)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, int32(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == 0 {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, oi.OrElse(0))
+
+	case "Rune":
+		oi := v.Interface().(optional.Rune)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, rune(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == 0 {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, oi.OrElse(0))
+
+	case "Int64":
+		oi := v.Interface().(optional.Int64)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, int64(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == 0 {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, oi.OrElse(0))
+
+	case "Int":
+		oi := v.Interface().(optional.Int)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, int64(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == 0 {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, int64(oi.OrElse(0)))
+
+	case "Uint8":
+		oi := v.Interface().(optional.Uint8)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, uint8(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == 0 {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, oi.OrElse(0))
+
+	case "Uint16":
+		oi := v.Interface().(optional.Uint16)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, uint16(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == 0 {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, oi.OrElse(0))
+
+	case "Uint32":
+		oi := v.Interface().(optional.Uint32)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, uint32(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == 0 {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, oi.OrElse(0))
+
+	case "Uint64":
+		oi := v.Interface().(optional.Uint64)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, uint64(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == 0 {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, oi.OrElse(0))
+
+	case "Uint":
+		oi := v.Interface().(optional.Uint)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, uint64(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == 0 {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, uint64(oi.OrElse(0)))
+
+	case "Float32":
+		oi := v.Interface().(optional.Float32)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, float32(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == 0.0 {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, oi.OrElse(0))
+
+	case "Float64":
+		oi := v.Interface().(optional.Float64)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, float64(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == 0.0 {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, oi.OrElse(0))
+
+	case "Complex64":
+		oi := v.Interface().(optional.Complex64)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, complex64(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == complex64(0) {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, oi.OrElse(0))
+
+	case "Complex128":
+		oi := v.Interface().(optional.Complex128)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, complex128(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == complex128(0) {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, oi.OrElse(0))
+
+	case "Uintptr":
+		oi := v.Interface().(optional.Uintptr)
+		if w.opts.ZeroNil && !oi.Present() {
+			return binary.Write(w.h, binary.LittleEndian, int64(0))
+		}
+		if w.opts.IgnoreZeroValue && oi.OrElse(0) == uintptr(0) {
+			return nil
+		}
+		if !oi.Present() {
+			_, err := fmt.Fprint(w.h, "nil")
+			return err
+		}
+		return binary.Write(w.h, binary.LittleEndian, int64(oi.OrElse(0)))
+	}
+
+	return fmt.Errorf("unsupported optional type: %s", typeName)
+}

--- a/optional_test.go
+++ b/optional_test.go
@@ -1,0 +1,49 @@
+package hashstructure
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/markphelps/optional"
+)
+
+type optionalStruct struct {
+	Int    optional.Int
+	String optional.String
+	Bool   optional.Bool
+}
+
+type outerStruct struct {
+	Int         int
+	InnerStruct *optionalStruct
+}
+
+func TestOptional(t *testing.T) {
+	s1 := &outerStruct{
+		Int: 42,
+		InnerStruct: &optionalStruct{
+			Int:    optional.NewInt(3),
+			String: optional.NewString("hello"),
+		},
+	}
+	s2 := &outerStruct{
+		Int: 42,
+		InnerStruct: &optionalStruct{
+			Int:  optional.NewInt(2),
+			Bool: optional.NewBool(false),
+		},
+	}
+
+	h1, err := Hash(s1, FormatMD5, nil)
+	if err != nil {
+		t.Errorf("error hashing s1: %v", err)
+	}
+	h2, err := Hash(s2, FormatMD5, nil)
+	if err != nil {
+		t.Errorf("error hashing s2: %v", err)
+	}
+
+	if bytes.Equal(h1, h2) {
+		t.Error("hashes were equal and should have been different")
+	}
+}


### PR DESCRIPTION
Previously, structs which differ only in the contents of optional fields (from github.com/markphelps/optional) would be hashed to the same value because the reflection would not access the private field that holds the actual value.

Now, we use reflection to call the unboxing methods on the optional types to include the underlying value in the hash.

**Testing**: New unit test